### PR TITLE
Add payload logging and exponential sleep deduplication

### DIFF
--- a/config/slack-logging.php
+++ b/config/slack-logging.php
@@ -13,7 +13,18 @@ return [
     */
     'lines_count' => 12,
 
-    'sleep' => 60,
+    /*
+    |--------------------------------------------------------------------------
+    | Sleep (deduplication)
+    |--------------------------------------------------------------------------
+    |
+    | After sending an exception to Slack, subsequent identical exceptions
+    | will be suppressed for an escalating duration (in seconds).
+    | First duplicate sleeps for 60s, second for 120s, third+ for 300s.
+    | Set to an empty array or [0] to disable.
+    |
+    */
+    'sleep' => [60, 120, 300],
 
     'webhook_url' => env('SLACK_LOGGING_WEBHOOK_URL', env('LOG_SLACK_WEBHOOK_URL')),
 

--- a/src/Facades/SlackLogging.php
+++ b/src/Facades/SlackLogging.php
@@ -6,10 +6,7 @@ use Illuminate\Support\Facades\Facade;
 use Kevariable\SlackLogging\SlackLoggingFake;
 
 /**
- * @method static void assertSent($throwable, $callback = null)
  * @method static void assertRequestsSent(int $expectedCount)
- * @method static void assertNotSent($throwable, $callback = null)
- * @method static void assertNothingSent()
  *
  * @see \Kevariable\SlackLogging\SlackLogging
  */

--- a/src/SlackLogging.php
+++ b/src/SlackLogging.php
@@ -4,7 +4,6 @@ namespace Kevariable\SlackLogging;
 
 use GuzzleHttp\Exception\RequestException;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Foundation\Application;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Notifications\Slack\BlockKit\Blocks\SectionBlock;
 use Illuminate\Notifications\Slack\SlackMessage;
@@ -62,7 +61,7 @@ class SlackLogging
         $data['host'] = Request::server('SERVER_NAME');
         $data['method'] = Request::method();
         $data['fullUrl'] = Request::fullUrl();
-        $data['exception'] = $exception->getMessage() ?? '-';
+        $data['exception'] = $exception->getMessage();
         $data['error'] = $exception->getTraceAsString();
         $data['line'] = $exception->getLine();
         $data['file'] = $exception->getFile();
@@ -179,7 +178,7 @@ class SlackLogging
                 $block->field("*Date:*\n{$date}")->markdown();
             })
             ->sectionBlock(function (SectionBlock $block) use ($exception) {
-                $payload = json_encode($exception['storage']['PARAMETERS'] ?? [], JSON_PRETTY_PRINT);
+                $payload = json_encode(($exception['storage']['PARAMETERS'] ?? []), JSON_PRETTY_PRINT);
                 $block->text(
                     "*Payload*: ```{$payload}```"
                 )->markdown();
@@ -218,7 +217,7 @@ class SlackLogging
 
     public function getUser(): ?array
     {
-        if (function_exists('auth') && (app() instanceof Application && auth()->check())) {
+        if (function_exists('auth') && auth()->check()) {
             /** @var \Illuminate\Contracts\Auth\Authenticatable $user */
             $user = auth()->user();
 

--- a/src/SlackLogging.php
+++ b/src/SlackLogging.php
@@ -2,8 +2,6 @@
 
 namespace Kevariable\SlackLogging;
 
-use GuzzleHttp\Exception\RequestException;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Notifications\Slack\BlockKit\Blocks\SectionBlock;
 use Illuminate\Notifications\Slack\SlackMessage;
@@ -36,6 +34,8 @@ class SlackLogging
         }
 
         $this->logError($data);
+
+        $this->putExceptionToSleep($data);
 
         return true;
     }
@@ -101,21 +101,13 @@ class SlackLogging
         }
         $data['executor'] = array_filter($data['executor']);
 
-        // to make symfony exception more readable
-        if ($data['class'] == 'Symfony\Component\Debug\Exception\FatalErrorException') {
-            preg_match("~^(.+)' in ~", $data['exception'], $matches);
-            if (isset($matches[1])) {
-                $data['exception'] = $matches[1];
-            }
-        }
-
         return $data;
     }
 
-    public function filterParameterValues(array $parameters): array
+    protected function filterParameterValues(array $parameters): array
     {
         return collect($parameters)->map(function ($value) {
-            if ($this->shouldParameterValueBeFiltered($value)) {
+            if ($value instanceof UploadedFile) {
                 return '...';
             }
 
@@ -124,20 +116,12 @@ class SlackLogging
     }
 
     /**
-     * Determines whether the given parameter value should be filtered.
-     */
-    public function shouldParameterValueBeFiltered(mixed $value): bool
-    {
-        return $value instanceof UploadedFile;
-    }
-
-    /**
      * Gets information from the line.
      *
      *
      * @return array|void
      */
-    private function getLineInfo($lines, $line, $i)
+    protected function getLineInfo($lines, $line, $i)
     {
         $currentLine = $line + $i;
 
@@ -158,7 +142,7 @@ class SlackLogging
         return in_array($exceptionClass, config('slack-logging.except'));
     }
 
-    private function logError($exception): void
+    protected function logError($exception): void
     {
         $date = date(format: 'Y-m-d H:i:s');
         $parameters = $exception['storage']['PARAMETERS'] ?? null;
@@ -198,40 +182,59 @@ class SlackLogging
 
         try {
             Http::post(url: $url, data: $slack->toArray());
-        } catch (RequestException $e) {
-            $e->getResponse();
-
-            return;
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return;
         }
     }
 
     public function isSleepingException(array $data): bool
     {
-        if (config('slack-logging.sleep', 0) == 0) {
+        $sleepSteps = $this->getSleepSteps();
+
+        if ($sleepSteps === []) {
             return false;
         }
 
-        return Cache::has($this->createExceptionString($data));
-    }
+        $cacheKey = $this->createExceptionString($data);
+        $occurrence = Cache::get($cacheKey);
 
-    private function createExceptionString(array $data): string
-    {
-        return 'slack-logging.'.Str::slug($data['host'].'_'.$data['method'].'_'.$data['exception'].'_'.$data['line'].'_'.$data['file'].'_'.$data['class']);
-    }
-
-    public function getUser(): ?array
-    {
-        if (function_exists('auth') && auth()->check()) {
-            /** @var \Illuminate\Contracts\Auth\Authenticatable $user */
-            $user = auth()->user();
-
-            if ($user instanceof Model) {
-                return $user->toArray();
-            }
+        if ($occurrence === null) {
+            return false;
         }
 
-        return null;
+        // Bump occurrence and extend TTL with the next sleep step
+        $nextOccurrence = $occurrence + 1;
+        $ttl = $sleepSteps[min($nextOccurrence - 1, count($sleepSteps) - 1)];
+
+        Cache::put($cacheKey, $nextOccurrence, $ttl);
+
+        return true;
+    }
+
+    protected function putExceptionToSleep(array $data): void
+    {
+        $sleepSteps = $this->getSleepSteps();
+
+        if ($sleepSteps === []) {
+            return;
+        }
+
+        Cache::put($this->createExceptionString($data), 1, $sleepSteps[0]);
+    }
+
+    protected function getSleepSteps(): array
+    {
+        $sleep = config('slack-logging.sleep', 0);
+
+        if (is_int($sleep)) {
+            return $sleep == 0 ? [] : [$sleep];
+        }
+
+        return array_filter((array) $sleep);
+    }
+
+    protected function createExceptionString(array $data): string
+    {
+        return 'slack-logging.'.Str::slug($data['host'].'_'.$data['method'].'_'.$data['exception'].'_'.$data['line'].'_'.$data['file'].'_'.$data['class']);
     }
 }

--- a/src/SlackLoggingFake.php
+++ b/src/SlackLoggingFake.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\Assert as PHPUnit;
 
 class SlackLoggingFake extends SlackLogging
 {
-    /** @var class-string[][] */
+    /** @var \Throwable[] */
     public array $exceptions = [];
 
     public function assertRequestsSent(int $expectedCount): void
@@ -16,7 +16,23 @@ class SlackLoggingFake extends SlackLogging
 
     public function handle(\Throwable $exception): bool
     {
-        $this->exceptions[get_class($exception)][] = $exception;
+        if ($this->isSkipEnvironment()) {
+            return false;
+        }
+
+        $data = $this->getExceptionData($exception);
+
+        if ($this->isSkipException($data['class'])) {
+            return false;
+        }
+
+        if ($this->isSleepingException($data)) {
+            return false;
+        }
+
+        $this->exceptions[] = $exception;
+
+        $this->putExceptionToSleep($data);
 
         return true;
     }

--- a/tests/LoggingTest.php
+++ b/tests/LoggingTest.php
@@ -3,9 +3,12 @@
 namespace Kevariable\SlackLogging\Tests;
 
 use Exception;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Kevariable\SlackLogging\Facades\SlackLogging;
+use Kevariable\SlackLogging\SlackLogging as SlackLoggingInstance;
 use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class LoggingTest extends TestCase
 {
@@ -47,6 +50,160 @@ class LoggingTest extends TestCase
         });
 
         $this->get('/throwables-via-route');
+
+        SlackLogging::assertRequestsSent(1);
+    }
+
+    #[Test]
+    public function it_will_not_send_duplicate_exceptions_to_slack()
+    {
+        config()->set('slack-logging.sleep', [60, 120, 300]);
+
+        $this->app['router']->get('/duplicate-exception', function () {
+            throw new Exception('Duplicate exception.');
+        });
+
+        $this->get('/duplicate-exception');
+        $this->get('/duplicate-exception');
+        $this->get('/duplicate-exception');
+
+        SlackLogging::assertRequestsSent(1);
+    }
+
+    #[Test]
+    public function it_will_send_duplicate_exceptions_when_sleep_is_disabled()
+    {
+        config()->set('slack-logging.sleep', []);
+
+        $this->app['router']->get('/no-sleep-exception', function () {
+            throw new Exception('No sleep exception.');
+        });
+
+        $this->get('/no-sleep-exception');
+        $this->get('/no-sleep-exception');
+
+        SlackLogging::assertRequestsSent(2);
+    }
+
+    #[Test]
+    public function it_will_send_different_exceptions_even_with_sleep()
+    {
+        config()->set('slack-logging.sleep', [60, 120, 300]);
+
+        $this->app['router']->get('/exception-a', function () {
+            throw new Exception('Exception A.');
+        });
+
+        $this->app['router']->get('/exception-b', function () {
+            throw new \RuntimeException('Exception B.');
+        });
+
+        $this->get('/exception-a');
+        $this->get('/exception-b');
+
+        SlackLogging::assertRequestsSent(2);
+    }
+
+    #[Test]
+    public function it_will_not_send_skipped_exceptions()
+    {
+        config()->set('slack-logging.except', [
+            NotFoundHttpException::class,
+        ]);
+
+        $this->app['router']->get('/not-found', function () {
+            throw new NotFoundHttpException('Not found.');
+        });
+
+        $this->get('/not-found');
+
+        SlackLogging::assertRequestsSent(0);
+    }
+
+    #[Test]
+    public function it_will_not_send_when_environment_is_not_configured()
+    {
+        config()->set('slack-logging.environments', ['production']);
+
+        $this->app['router']->get('/wrong-env', function () {
+            throw new Exception('Wrong environment.');
+        });
+
+        $this->get('/wrong-env');
+
+        SlackLogging::assertRequestsSent(0);
+    }
+
+    #[Test]
+    public function it_will_not_send_when_environments_is_empty()
+    {
+        config()->set('slack-logging.environments', []);
+
+        $this->app['router']->get('/empty-env', function () {
+            throw new Exception('Empty environments.');
+        });
+
+        $this->get('/empty-env');
+
+        SlackLogging::assertRequestsSent(0);
+    }
+
+    #[Test]
+    public function it_will_send_again_after_cache_expires()
+    {
+        config()->set('slack-logging.sleep', [60]);
+
+        $this->app['router']->get('/cache-expire', function () {
+            throw new Exception('Cache expire exception.');
+        });
+
+        $this->get('/cache-expire');
+        SlackLogging::assertRequestsSent(1);
+
+        Cache::flush();
+
+        $this->get('/cache-expire');
+        SlackLogging::assertRequestsSent(2);
+    }
+
+    #[Test]
+    public function it_escalates_sleep_duration_on_repeated_exceptions()
+    {
+        config()->set('slack-logging.sleep', [60, 120, 300]);
+
+        /** @var SlackLoggingInstance $instance */
+        $instance = app('slack-logging');
+
+        $exception = new Exception('Escalating exception.');
+        $data = $instance->getExceptionData($exception);
+
+        // Not sleeping yet
+        $this->assertFalse($instance->isSleepingException($data));
+
+        // First send — puts to sleep with 60s TTL (occurrence=1)
+        $instance->handle($exception);
+
+        // Now sleeping — occurrence bumps to 2, TTL extended to 120s
+        $this->assertTrue($instance->isSleepingException($data));
+
+        // Still sleeping — occurrence bumps to 3, TTL extended to 300s (max step)
+        $this->assertTrue($instance->isSleepingException($data));
+
+        // Still sleeping — stays at 300s (capped at last step)
+        $this->assertTrue($instance->isSleepingException($data));
+    }
+
+    #[Test]
+    public function it_supports_legacy_integer_sleep_config()
+    {
+        config()->set('slack-logging.sleep', 60);
+
+        $this->app['router']->get('/legacy-sleep', function () {
+            throw new Exception('Legacy sleep.');
+        });
+
+        $this->get('/legacy-sleep');
+        $this->get('/legacy-sleep');
 
         SlackLogging::assertRequestsSent(1);
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -19,6 +19,7 @@ class TestCase extends Orchestra
     public function getEnvironmentSetUp($app): void
     {
         config()->set('database.default', 'testing');
+        config()->set('cache.default', 'array');
 
         /*
          foreach (\Illuminate\Support\Facades\File::allFiles(__DIR__ . '/database/migrations') as $migration) {


### PR DESCRIPTION
## Summary
- **Payload logging**: Include request parameters in Slack notification when available
- **Exponential sleep deduplication**: Suppress duplicate exceptions with escalating cooldown `[60s, 120s, 300s]` — configurable via `slack-logging.sleep`
- **Dead code cleanup**: Remove unused `getUser()`, `shouldParameterValueBeFiltered()`, Symfony `FatalErrorException` handling, and phantom facade methods
- **SlackLoggingFake**: Now mirrors real `handle()` logic (environment check, skip list, dedup)

## Test plan
- [x] Duplicate exceptions are suppressed within sleep window
- [x] Different exceptions are sent even with sleep enabled
- [x] Sleep disabled when config is `[]` or `0`
- [x] Escalation bumps TTL through configured steps
- [x] Cache expiry allows re-sending
- [x] Skipped exceptions and wrong environments are not sent
- [x] Legacy integer sleep config still works
- [x] All 11 tests passing